### PR TITLE
Stringify delete keyword

### DIFF
--- a/WeakMap.js
+++ b/WeakMap.js
@@ -26,7 +26,7 @@ if (typeof WeakMap === 'undefined') {
         return (entry = key[this.name]) && entry[0] === key ?
             entry[1] : undefined;
       },
-      delete: function(key) {
+      'delete': function(key) {
         this.set(key, undefined);
       }
     };


### PR DESCRIPTION
Old ECMAScript standard (< ES5)  interprets `delete` as a keyword and throws when used for an object property. When passing `delete` as a string it will work.
